### PR TITLE
add custom starjump blocks

### DIFF
--- a/Ahorn/entities/FragmentsStarJumpBlock.jl
+++ b/Ahorn/entities/FragmentsStarJumpBlock.jl
@@ -1,0 +1,180 @@
+module AnarchyCollab2022FragmentsStarJumpBlock
+
+using ..Ahorn, Maple
+
+@mapdef Entity "AnarchyCollab2022/FragmentsStarJumpBlock" FragmentsStarJumpBlock(
+  x::Integer, y::Integer,
+  width::Integer=16, height::Integer=16,
+  sinks::Bool=true
+)
+
+@mapdef Entity "AnarchyCollab2022/FragmentsStarJumpController" FragmentsStarJumpController(
+  x::Integer, y::Integer
+)
+
+const placements = Ahorn.PlacementDict(
+    "Fragments Star Jump Block (AnarchyCollab2022)" => Ahorn.EntityPlacement(
+        FragmentsStarJumpBlock,
+        "rectangle"
+    ),
+    "Fragments Star Climb Graphics Controller (AnarchyCollab2022)" => Ahorn.EntityPlacement(
+      FragmentsStarJumpController,
+    ),
+)
+
+Ahorn.minimumSize(entity::FragmentsStarJumpBlock) = 8, 8
+Ahorn.resizable(entity::FragmentsStarJumpBlock) = true, true
+
+Ahorn.selection(entity::FragmentsStarJumpBlock) = Ahorn.getEntityRectangle(entity)
+
+function Ahorn.selection(entity::FragmentsStarJumpController)
+    x, y = Ahorn.position(entity)
+
+    return Ahorn.Rectangle(x - 12, y - 12, 24, 24)
+end
+
+function getStarjumpRectangles(room::Maple.Room)
+    entities = filter(e -> e.name == "AnarchyCollab2022/FragmentsStarJumpBlock", room.entities)
+    rects = Ahorn.Rectangle[
+        Ahorn.Rectangle(
+            Int(get(e.data, "x", 0)),
+            Int(get(e.data, "y", 0)),
+            Int(get(e.data, "width", 8)),
+            Int(get(e.data, "height", 8))
+        ) for e in entities
+    ]
+
+    return rects
+end
+
+# Is there a star block we should connect to at the offset?
+function noAdjacent(entity::FragmentsStarJumpBlock, ox::Integer, oy::Integer, rects::Array{Ahorn.Rectangle, 1})
+    x, y = Ahorn.position(entity)
+
+    rect = Ahorn.Rectangle(x + ox + 4, y + oy + 4, 1, 1)
+
+    return !any(Ahorn.checkCollision.(rects, Ref(rect)))
+end
+
+const fillColor = (255, 255, 255, 255) ./ 255
+const corners = String[
+    "objects/starjumpBlock/corner00.png",
+    "objects/starjumpBlock/corner01.png",
+    "objects/starjumpBlock/corner02.png",
+    "objects/starjumpBlock/corner03.png"
+]
+const edgeHs = String[
+    "objects/starjumpBlock/edgeH00.png",
+    "objects/starjumpBlock/edgeH01.png",
+    "objects/starjumpBlock/edgeH02.png",
+    "objects/starjumpBlock/edgeH03.png",
+]
+const edgeVs = String[
+    "objects/starjumpBlock/edgeV00.png",
+    "objects/starjumpBlock/edgeV01.png",
+    "objects/starjumpBlock/edgeV02.png",
+    "objects/starjumpBlock/edgeV03.png",
+]
+
+function renderStarjumpBlock(ctx::Ahorn.Cairo.CairoContext, entity::FragmentsStarJumpBlock, room::Maple.Room)
+    starJumpRectangles = getStarjumpRectangles(room)
+    rng = Ahorn.getSimpleEntityRng(entity)
+
+    x, y = Ahorn.position(entity)
+
+    width = Int(get(entity.data, "width", 32))
+    height = Int(get(entity.data, "height", 32))
+
+    # Horizontal Border
+    w = 8
+    while w < width - 8
+        if noAdjacent(entity, w, -8, starJumpRectangles)
+            edge = rand(rng, edgeHs)
+            Ahorn.drawSprite(ctx, edge, w + 4, 4)
+        end
+
+        if noAdjacent(entity, w, height, starJumpRectangles)
+            texture = rand(rng, edgeHs)
+            Ahorn.drawSprite(ctx, texture, w + 4, height - 4, sy=-1)
+        end
+
+        w += 8
+    end
+
+    # Vertical Border
+    h = 8
+    while h < height - 8
+        if noAdjacent(entity, -8, h, starJumpRectangles)
+            texture = rand(rng, edgeVs)
+            Ahorn.drawSprite(ctx, texture, 4, h + 4, sx=-1)
+        end
+
+        if noAdjacent(entity, width, h, starJumpRectangles)
+            texture = rand(rng, edgeVs)
+            Ahorn.drawSprite(ctx, texture, width - 4, h + 4)
+        end
+
+        h += 8
+    end
+
+    # Top Left Corner
+    if noAdjacent(entity, -8, 0, starJumpRectangles) && noAdjacent(entity, 0, -8, starJumpRectangles)
+        corner = rand(rng, corners)
+        Ahorn.drawSprite(ctx, corner, 4, 4, sx=-1)
+
+    elseif noAdjacent(entity, -8, 0, starJumpRectangles)
+        corner = rand(rng, edgeVs)
+        Ahorn.drawSprite(ctx, corner, 4, 4, sx=-1)
+
+    elseif noAdjacent(entity, 0, -8, starJumpRectangles)
+        corner = rand(rng, edgeHs)
+        Ahorn.drawSprite(ctx, corner, 4, 4, sx=-1)
+    end
+
+    # Top Right Corner
+    if noAdjacent(entity, width, 0, starJumpRectangles) && noAdjacent(entity, width - 8, -8, starJumpRectangles)
+        corner = rand(rng, corners)
+        Ahorn.drawSprite(ctx, corner, width - 4, 4)
+
+    elseif noAdjacent(entity, width, 0, starJumpRectangles)
+        corner = rand(rng, edgeVs)
+        Ahorn.drawSprite(ctx, corner, width - 4, 4)
+
+    elseif noAdjacent(entity, width - 8, -8, starJumpRectangles)
+        corner = rand(rng, edgeHs)
+        Ahorn.drawSprite(ctx, corner, width - 4, 4)
+    end
+
+    # Bottom Left Corner
+    if noAdjacent(entity, -8, height - 8, starJumpRectangles) && noAdjacent(entity, 0, height, starJumpRectangles)
+        corner = rand(rng, corners)
+        Ahorn.drawSprite(ctx, corner, 4, height - 4, sx=-1, sy=-1)
+
+    elseif noAdjacent(entity, -8, height - 8, starJumpRectangles)
+        corner = rand(rng, edgeVs)
+        Ahorn.drawSprite(ctx, corner, 4, height - 4, sx=-1, sy=-1)
+
+    elseif noAdjacent(entity, 0, height, starJumpRectangles)
+        corner = rand(rng, edgeHs)
+        Ahorn.drawSprite(ctx, corner, 4, height - 4, sx=-1, sy=-1)
+    end
+
+    # Bottom Right Corner
+    if noAdjacent(entity, width, height - 8, starJumpRectangles) && noAdjacent(entity, width - 8, height, starJumpRectangles)
+        corner = rand(rng, corners)
+        Ahorn.drawSprite(ctx, corner, width - 4, height - 4, sy=-1)
+
+    elseif noAdjacent(entity, width, height - 8, starJumpRectangles)
+        corner = rand(rng, edgeVs)
+        Ahorn.drawSprite(ctx, corner, width - 4, height - 4, sy=-1)
+
+    elseif noAdjacent(entity, width - 8, height, starJumpRectangles)
+        corner = rand(rng, edgeHs)
+        Ahorn.drawSprite(ctx, corner, width - 4, height - 4, sy=-1)
+    end
+end
+
+Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::FragmentsStarJumpBlock, room::Maple.Room) = renderStarjumpBlock(ctx, entity, room)
+Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::FragmentsStarJumpController, room::Maple.Room) = Ahorn.drawImage(ctx, Ahorn.Assets.northernLights, -12, -12)
+
+end

--- a/src/FragmentsStarJumpBlock.cs
+++ b/src/FragmentsStarJumpBlock.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Monocle;
+using Celeste;
+using Celeste.Mod.Entities;
+
+namespace Celeste.Mod.AnarchyCollab2022 {
+    [Tracked(false)]
+    [CustomEntity("AnarchyCollab2022/FragmentsStarJumpBlock")]
+    public class FragmentsStarJumpBlock : Solid {
+        private bool sinks;
+        private float startY;
+        private float yLerp;
+        private float sinkTimer;
+
+        public FragmentsStarJumpBlock(EntityData data, Vector2 offset) : base(data.Position + offset, data.Width, data.Height, safe: false) {
+            Depth = -9000;
+            sinks = data.Bool("sinks");
+
+            Add(new LightOcclude());
+            startY = Y;
+            SurfaceSoundIndex = SurfaceIndex.AuroraGlass;
+        }
+
+        public override void Awake(Scene scene) {
+            base.Awake(scene);
+            List<MTexture> tex_edge_h = GFX.Game.GetAtlasSubtextures("objects/starjumpBlock/edgeH");
+            List<MTexture> tex_edge_v = GFX.Game.GetAtlasSubtextures("objects/starjumpBlock/edgeV");
+            List<MTexture> tex_corner = GFX.Game.GetAtlasSubtextures("objects/starjumpBlock/corner");
+            for (int i = 8; (float)i < base.Width - 8f; i += 8) {
+                if (Open(i, -8f)) {
+                    Image edge_h = new Image(Calc.Random.Choose(tex_edge_h));
+                    edge_h.CenterOrigin();
+                    edge_h.Position = new Vector2(i + 4, 4f);
+                    Add(edge_h);
+                }
+                if (Open(i, base.Height)) {
+                    Image edge_h = new Image(Calc.Random.Choose(tex_edge_h));
+                    edge_h.CenterOrigin();
+                    edge_h.Scale.Y = -1f;
+                    edge_h.Position = new Vector2(i + 4, base.Height - 4f);
+                    Add(edge_h);
+                }
+            }
+            for (int j = 8; (float)j < base.Height - 8f; j += 8) {
+                if (Open(-8f, j)) {
+                    Image edge_v = new Image(Calc.Random.Choose(tex_edge_v));
+                    edge_v.CenterOrigin();
+                    edge_v.Scale.X = -1f;
+                    edge_v.Position = new Vector2(4f, j + 4);
+                    Add(edge_v);
+                }
+                if (Open(base.Width, j)) {
+                    Image edge_v = new Image(Calc.Random.Choose(tex_edge_v));
+                    edge_v.CenterOrigin();
+                    edge_v.Position = new Vector2(base.Width - 4f, j + 4);
+                    Add(edge_v);
+                }
+            }
+            Image corner = null;
+            if (Open(-8f, 0f) && Open(0f, -8f)) {
+                corner = new Image(Calc.Random.Choose(tex_corner));
+                corner.Scale.X = -1f;
+            } else if (Open(-8f, 0f)) {
+                corner = new Image(Calc.Random.Choose(tex_edge_v));
+                corner.Scale.X = -1f;
+            } else if (Open(0f, -8f)) {
+                corner = new Image(Calc.Random.Choose(tex_edge_h));
+            }
+            if (corner != null) {
+                corner.CenterOrigin();
+                corner.Position = new Vector2(4f, 4f);
+                Add(corner);
+            }
+            corner = null;
+            if (Open(base.Width, 0f) && Open(base.Width - 8f, -8f)) {
+                corner = new Image(Calc.Random.Choose(tex_corner));
+            } else if (Open(base.Width, 0f)) {
+                corner = new Image(Calc.Random.Choose(tex_edge_v));
+            } else if (Open(base.Width - 8f, -8f)) {
+                corner = new Image(Calc.Random.Choose(tex_edge_h));
+            }
+            if (corner != null) {
+                corner.CenterOrigin();
+                corner.Position = new Vector2(base.Width - 4f, 4f);
+                Add(corner);
+            }
+            corner = null;
+            if (Open(-8f, base.Height - 8f) && Open(0f, base.Height)) {
+                corner = new Image(Calc.Random.Choose(tex_corner));
+                corner.Scale.X = -1f;
+            } else if (Open(-8f, base.Height - 8f)) {
+                corner = new Image(Calc.Random.Choose(tex_edge_v));
+                corner.Scale.X = -1f;
+            } else if (Open(0f, base.Height)) {
+                corner = new Image(Calc.Random.Choose(tex_edge_h));
+            }
+            if (corner != null) {
+                corner.Scale.Y = -1f;
+                corner.CenterOrigin();
+                corner.Position = new Vector2(4f, base.Height - 4f);
+                Add(corner);
+            }
+            corner = null;
+            if (Open(base.Width, base.Height - 8f) && Open(base.Width - 8f, base.Height)) {
+                corner = new Image(Calc.Random.Choose(tex_corner));
+            } else if (Open(base.Width, base.Height - 8f)) {
+                corner = new Image(Calc.Random.Choose(tex_edge_v));
+            } else if (Open(base.Width - 8f, base.Height)) {
+                corner = new Image(Calc.Random.Choose(tex_edge_h));
+            }
+            if (corner != null) {
+                corner.Scale.Y = -1f;
+                corner.CenterOrigin();
+                corner.Position = new Vector2(base.Width - 4f, base.Height - 4f);
+                Add(corner);
+            }
+        }
+
+        private bool Open(float x, float y) {
+            return !base.Scene.CollideCheck<FragmentsStarJumpBlock>(new Vector2(base.X + x + 4f, base.Y + y + 4f));
+        }
+
+        public override void Update() {
+            base.Update();
+
+            if (sinks) {
+                if (HasPlayerRider()) {
+                    sinkTimer = 0.1f;
+                } else if (sinkTimer > 0f) {
+                    sinkTimer -= Engine.DeltaTime;
+                }
+                if (sinkTimer > 0f) {
+                    yLerp = Calc.Approach(yLerp, 1f, 1f * Engine.DeltaTime);
+                } else {
+                    yLerp = Calc.Approach(yLerp, 0f, 1f * Engine.DeltaTime);
+                }
+                float y = MathHelper.Lerp(startY, startY + 12f, Ease.SineInOut(yLerp));
+                MoveToY(y);
+            }
+        }
+
+        public override void Render() {
+            if (Scene.Tracker.GetEntity<FragmentsStarJumpController>() != null) {
+                Logger.Log("FragmentsStarJumpBlock", "found controller");
+                VirtualRenderTarget blockFill = FragmentsStarJumpController.BlockFill;
+
+                if (blockFill != null) {
+                    Logger.Log("FragmentsStarJumpBlock", "drawing from block fill texture");
+                    Vector2 camera_pos = SceneAs<Level>().Camera.Position.Floor();
+                    Rectangle sourceRectangle = new Rectangle((int)(base.X - camera_pos.X), (int)(base.Y - camera_pos.Y), (int)base.Width, (int)base.Height);
+
+                    Draw.SpriteBatch.Draw((RenderTarget2D)blockFill, Position, sourceRectangle, Color.White);
+                }
+            }
+
+            base.Render();
+        }
+    }
+}

--- a/src/FragmentsStarJumpBlock.cs
+++ b/src/FragmentsStarJumpBlock.cs
@@ -143,11 +143,9 @@ namespace Celeste.Mod.AnarchyCollab2022 {
 
         public override void Render() {
             if (Scene.Tracker.GetEntity<FragmentsStarJumpController>() != null) {
-                Logger.Log("FragmentsStarJumpBlock", "found controller");
                 VirtualRenderTarget blockFill = FragmentsStarJumpController.BlockFill;
 
                 if (blockFill != null) {
-                    Logger.Log("FragmentsStarJumpBlock", "drawing from block fill texture");
                     Vector2 camera_pos = SceneAs<Level>().Camera.Position.Floor();
                     Rectangle sourceRectangle = new Rectangle((int)(base.X - camera_pos.X), (int)(base.Y - camera_pos.Y), (int)base.Width, (int)base.Height);
 

--- a/src/FragmentsStarJumpController.cs
+++ b/src/FragmentsStarJumpController.cs
@@ -90,14 +90,14 @@ namespace Celeste.Mod.AnarchyCollab2022 {
             Engine.Graphics.GraphicsDevice.Clear(Color.Black);
 
             foreach (var bg in backdrops) {
-                float alpha = bg.FadeAlphaMultiplier;
+                float original_fade = bg.FadeAlphaMultiplier;
                 bg.FadeAlphaMultiplier = 1f;
                 Draw.SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.None, RasterizerState.CullNone);
                 if (bg is NorthernLights) {
-                    Array particles = new DynamicData(bg).Get<Array>("particles");
+                    Array particles = DynamicData.For(bg).Get<Array>("particles");
 
                     for (int i = 0; i < particles.Length; i++) {
-                        DynamicData particleData = new DynamicData(particles.GetValue(i));
+                        var particleData = DynamicData.For(particles.GetValue(i));
                         var pos = particleData.Get<Vector2>("Position");
 
                         Draw.Rect(new Vector2(mod(pos.X - camera.X * 0.2f, 320f),
@@ -120,7 +120,7 @@ namespace Celeste.Mod.AnarchyCollab2022 {
                     bg.Render(level);
                 }
                 Draw.SpriteBatch.End();
-                bg.FadeAlphaMultiplier = alpha;
+                bg.FadeAlphaMultiplier = original_fade;
             }
         }
 

--- a/src/FragmentsStarJumpController.cs
+++ b/src/FragmentsStarJumpController.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Monocle;
+using Celeste;
+using Celeste.Mod.Entities;
+using MonoMod.Utils;
+
+namespace Celeste.Mod.AnarchyCollab2022 {
+    [Tracked]
+    [CustomEntity("AnarchyCollab2022/FragmentsStarJumpController")]
+    public class FragmentsStarJumpController : Entity {
+        public static VirtualRenderTarget BlockFill;
+        public FragmentsStarJumpController Current = null;
+
+        private List<Backdrop> backdrops;
+
+        public FragmentsStarJumpController(EntityData data, Vector2 offset) : base(data.Position + offset) {
+            Tag = (int)Tags.TransitionUpdate | (int)Tags.FrozenUpdate;
+            // wipeColor = data.HexColor("wipeColor", Color.Black);
+        }
+
+        public override void Added(Scene scene) {
+            base.Added(scene);
+            if (Current == null) {
+                Current = this;
+                InitBlockFill();
+            }
+            Add(new BeforeRenderHook(BeforeRender));
+
+            backdrops = SceneAs<Level>().Background.Backdrops
+                .Where((bg) => bg.Tags.Contains("anarchycollab2022-fragments-block-fill"))
+                .ToList<Backdrop>();
+        }
+
+        public override void Update() {
+            base.Update();
+            if (Current == this) {
+                UpdateBlockFill();
+            }
+        }
+
+        private void InitBlockFill() {
+            // for (int i = 0; i < rays.Length; i++) {
+            //     rays[i].Reset();
+            //     rays[i].Percent = Calc.Random.NextFloat();
+            // }
+        }
+
+        private void UpdateBlockFill() {
+            // Vector2 vector = Calc.AngleToVector(-1.670796f, 1f);
+            // Vector2 vector2 = new Vector2(0f - vector.Y, vector.X);
+            // int num = 0;
+            // for (int i = 0; i < rays.Length; i++) {
+            //     if ((double)rays[i].Percent >= 1.0) {
+            //         rays[i].Reset();
+            //     }
+            //     rays[i].Percent += Engine.DeltaTime / rays[i].Duration;
+            //     rays[i].Y += 8f * Engine.DeltaTime;
+            //     Vector2 vector3 = new Vector2(mod(rays[i].X - level.Camera.X * 0.9f, 480f) - 80f, mod(rays[i].Y - level.Camera.Y * 0.7f, 580f) - 200f);
+            //     float width = rays[i].Width;
+            //     float length = rays[i].Length;
+            //     Color color = rayColor * Ease.CubeInOut(Calc.YoYo(rays[i].Percent));
+            //     VertexPositionColor vertexPositionColor = new VertexPositionColor(new Vector3(vector3 + vector2 * width + vector * length, 0f), color);
+            //     VertexPositionColor vertexPositionColor2 = new VertexPositionColor(new Vector3(vector3 - vector2 * width, 0f), color);
+            //     VertexPositionColor vertexPositionColor3 = new VertexPositionColor(new Vector3(vector3 + vector2 * width, 0f), color);
+            //     VertexPositionColor vertexPositionColor4 = new VertexPositionColor(new Vector3(vector3 - vector2 * width - vector * length, 0f), color);
+            //     vertices[num++] = vertexPositionColor;
+            //     vertices[num++] = vertexPositionColor2;
+            //     vertices[num++] = vertexPositionColor3;
+            //     vertices[num++] = vertexPositionColor2;
+            //     vertices[num++] = vertexPositionColor3;
+            //     vertices[num++] = vertexPositionColor4;
+            // }
+            // vertexCount = num;
+        }
+
+        private void BeforeRender() {
+            if (Current != this) {
+                return;
+            }
+
+            Level level = SceneAs<Level>();
+            Camera camera = level.Camera;
+
+            BlockFill ??= VirtualContent.CreateRenderTarget("anarchycollab2022-fragments-block-fill", 320, 180);
+            Engine.Graphics.GraphicsDevice.SetRenderTarget(BlockFill);
+            Engine.Graphics.GraphicsDevice.Clear(Color.Black);
+
+            foreach (var bg in backdrops) {
+                float alpha = bg.FadeAlphaMultiplier;
+                bg.FadeAlphaMultiplier = 1f;
+                Draw.SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.None, RasterizerState.CullNone);
+                if (bg is NorthernLights) {
+                    Array particles = new DynamicData(bg).Get<Array>("particles");
+
+                    for (int i = 0; i < particles.Length; i++) {
+                        DynamicData particleData = new DynamicData(particles.GetValue(i));
+                        var pos = particleData.Get<Vector2>("Position");
+
+                        Draw.Rect(new Vector2(mod(pos.X - camera.X * 0.2f, 320f),
+                                              mod(pos.Y - camera.Y * 0.2f, 180f)),
+                                  1f, 1f, particleData.Get<Color>("Color"));
+                    }
+                } else if (bg is Starfield) {
+                    var starfield = (Starfield)bg;
+
+                    for (int i = 0; i < starfield.Stars.Length; i++) {
+                        var star = starfield.Stars[i];
+                        Color color = star.Color;
+                        color.A = (byte)255;
+
+                        star.Texture.DrawCentered(new Vector2(-64f + mod(star.Position.X - camera.Position.X * starfield.Scroll.X, 448f),
+                                                              -16f + mod(star.Position.Y - camera.Position.Y * starfield.Scroll.Y, 212f)),
+                                                  color);
+                    }
+                } else {
+                    bg.Render(level);
+                }
+                Draw.SpriteBatch.End();
+                bg.FadeAlphaMultiplier = alpha;
+            }
+        }
+
+        public override void Removed(Scene scene) {
+            Dispose();
+            base.Removed(scene);
+        }
+
+        public override void SceneEnd(Scene scene) {
+            Dispose();
+            base.SceneEnd(scene);
+        }
+
+        private void Dispose() {
+            FragmentsStarJumpController successor = null;
+            foreach (var entity in SceneAs<Level>().Tracker.GetEntities<FragmentsStarJumpController>()) {
+                var controller = entity as FragmentsStarJumpController;
+                if (controller != null && controller != this) {
+                    successor = controller;
+                    break;
+                }
+            }
+
+            if (successor == null) {
+                BlockFill?.Dispose();
+                BlockFill = null;
+            }
+            Current = successor;
+        }
+
+        private static float mod(float x, float m) {
+            return (x % m + m) % m;
+        }
+    }
+}

--- a/src/FragmentsStarJumpController.cs
+++ b/src/FragmentsStarJumpController.cs
@@ -19,62 +19,18 @@ namespace Celeste.Mod.AnarchyCollab2022 {
 
         public FragmentsStarJumpController(EntityData data, Vector2 offset) : base(data.Position + offset) {
             Tag = (int)Tags.TransitionUpdate | (int)Tags.FrozenUpdate;
-            // wipeColor = data.HexColor("wipeColor", Color.Black);
         }
 
         public override void Added(Scene scene) {
             base.Added(scene);
             if (Current == null) {
                 Current = this;
-                InitBlockFill();
             }
             Add(new BeforeRenderHook(BeforeRender));
 
             backdrops = SceneAs<Level>().Background.Backdrops
                 .Where((bg) => bg.Tags.Contains("anarchycollab2022-fragments-block-fill"))
                 .ToList<Backdrop>();
-        }
-
-        public override void Update() {
-            base.Update();
-            if (Current == this) {
-                UpdateBlockFill();
-            }
-        }
-
-        private void InitBlockFill() {
-            // for (int i = 0; i < rays.Length; i++) {
-            //     rays[i].Reset();
-            //     rays[i].Percent = Calc.Random.NextFloat();
-            // }
-        }
-
-        private void UpdateBlockFill() {
-            // Vector2 vector = Calc.AngleToVector(-1.670796f, 1f);
-            // Vector2 vector2 = new Vector2(0f - vector.Y, vector.X);
-            // int num = 0;
-            // for (int i = 0; i < rays.Length; i++) {
-            //     if ((double)rays[i].Percent >= 1.0) {
-            //         rays[i].Reset();
-            //     }
-            //     rays[i].Percent += Engine.DeltaTime / rays[i].Duration;
-            //     rays[i].Y += 8f * Engine.DeltaTime;
-            //     Vector2 vector3 = new Vector2(mod(rays[i].X - level.Camera.X * 0.9f, 480f) - 80f, mod(rays[i].Y - level.Camera.Y * 0.7f, 580f) - 200f);
-            //     float width = rays[i].Width;
-            //     float length = rays[i].Length;
-            //     Color color = rayColor * Ease.CubeInOut(Calc.YoYo(rays[i].Percent));
-            //     VertexPositionColor vertexPositionColor = new VertexPositionColor(new Vector3(vector3 + vector2 * width + vector * length, 0f), color);
-            //     VertexPositionColor vertexPositionColor2 = new VertexPositionColor(new Vector3(vector3 - vector2 * width, 0f), color);
-            //     VertexPositionColor vertexPositionColor3 = new VertexPositionColor(new Vector3(vector3 + vector2 * width, 0f), color);
-            //     VertexPositionColor vertexPositionColor4 = new VertexPositionColor(new Vector3(vector3 - vector2 * width - vector * length, 0f), color);
-            //     vertices[num++] = vertexPositionColor;
-            //     vertices[num++] = vertexPositionColor2;
-            //     vertices[num++] = vertexPositionColor3;
-            //     vertices[num++] = vertexPositionColor2;
-            //     vertices[num++] = vertexPositionColor3;
-            //     vertices[num++] = vertexPositionColor4;
-            // }
-            // vertexCount = num;
         }
 
         private void BeforeRender() {


### PR DESCRIPTION
they render tagged styleground backdrops to their interiors, ignoring fade alpha values and with special behaviour for some effects:
- `Starfield` particles are rendered with full opacity, regardless of the alpha value
- `NorthernLights` effects are ignored, and only their particles are rendered

also, i didn't want the railings so these don't have them