### PR TITLE
stuff for Temple of Jank

### DIFF
--- a/Ahorn/entities/NoOutlineSwapBlock.jl
+++ b/Ahorn/entities/NoOutlineSwapBlock.jl
@@ -1,0 +1,111 @@
+module AnarchyCollab2022NoOutlineSwapBlock
+using ..Ahorn, Maple
+
+@mapdef Entity "AnarchyCollab2022/NoOutlineSwapBlock" NoOutlineSwapBlock(x1::Integer, y1::Integer, x2::Integer=x1+16, y2::Integer=y1, width::Integer=16, height::Integer=16, theme::String="Normal", speed::Integer=360)
+
+function swapFinalizer(entity)
+    x, y = Ahorn.position(entity)
+
+    width = Int(get(entity.data, "width", 8))
+    height = Int(get(entity.data, "height", 8))
+
+    entity.data["nodes"] = [(x + width, y)]
+end
+
+const placements = Ahorn.PlacementDict(
+    "No Outline Swap Block ($(uppercasefirst(theme))) (AnarchyCollab2022)" => Ahorn.EntityPlacement(
+        NoOutlineSwapBlock,
+        "rectangle",
+        Dict{String, Any}(
+            "theme" => theme
+        ),
+        swapFinalizer
+    ) for theme in Maple.swap_block_themes
+)
+
+Ahorn.editingOptions(entity::NoOutlineSwapBlock) = Dict{String, Any}(
+    "theme" => Maple.swap_block_themes
+)
+
+Ahorn.nodeLimits(entity::NoOutlineSwapBlock) = 1, 1
+
+Ahorn.minimumSize(entity::NoOutlineSwapBlock) = 16, 16
+Ahorn.resizable(entity::NoOutlineSwapBlock) = true, true
+
+function Ahorn.selection(entity::NoOutlineSwapBlock)
+    x, y = Ahorn.position(entity)
+    stopX, stopY = Int.(entity.data["nodes"][1])
+
+    width = Int(get(entity.data, "width", 8))
+    height = Int(get(entity.data, "height", 8))
+
+    return [Ahorn.Rectangle(x, y, width, height), Ahorn.Rectangle(stopX, stopY, width, height)]
+end
+
+function getTextures(entity::NoOutlineSwapBlock)
+    theme = lowercase(get(entity, "theme", "normal"))
+
+    if theme == "moon"
+        return "objects/swapblock/moon/blockRed", "objects/swapblock/moon/target", "objects/swapblock/moon/midBlockRed00"
+    end
+
+    return "objects/swapblock/blockRed", "objects/swapblock/target", "objects/swapblock/midBlockRed00"
+end
+
+function renderSwapBlock(ctx::Ahorn.Cairo.CairoContext, x::Int, y::Int, width::Int, height::Int, midResource::String, frame::String)
+    midSprite = Ahorn.getSprite(midResource, "Gameplay")
+    
+    tilesWidth = div(width, 8)
+    tilesHeight = div(height, 8)
+
+    for i in 2:tilesWidth - 1
+        Ahorn.drawImage(ctx, frame, x + (i - 1) * 8, y, 8, 0, 8, 8)
+        Ahorn.drawImage(ctx, frame, x + (i - 1) * 8, y + height - 8, 8, 16, 8, 8)
+    end
+
+    for i in 2:tilesHeight - 1
+        Ahorn.drawImage(ctx, frame, x, y + (i - 1) * 8, 0, 8, 8, 8)
+        Ahorn.drawImage(ctx, frame, x + width - 8, y + (i - 1) * 8, 16, 8, 8, 8)
+    end
+
+    for i in 2:tilesWidth - 1, j in 2:tilesHeight - 1
+        Ahorn.drawImage(ctx, frame, x + (i - 1) * 8, y + (j - 1) * 8, 8, 8, 8, 8)
+    end
+
+    Ahorn.drawImage(ctx, frame, x, y, 0, 0, 8, 8)
+    Ahorn.drawImage(ctx, frame, x + width - 8, y, 16, 0, 8, 8)
+    Ahorn.drawImage(ctx, frame, x, y + height - 8, 0, 16, 8, 8)
+    Ahorn.drawImage(ctx, frame, x + width - 8, y + height - 8, 16, 16, 8, 8)
+
+    Ahorn.drawImage(ctx, midSprite, x + div(width - midSprite.width, 2), y + div(height - midSprite.height, 2))
+end
+
+function Ahorn.renderSelectedAbs(ctx::Ahorn.Cairo.CairoContext, entity::NoOutlineSwapBlock, room::Maple.Room)
+    sprite = get(entity.data, "sprite", "block")
+    startX, startY = Int(entity.data["x"]), Int(entity.data["y"])
+    stopX, stopY = Int.(entity.data["nodes"][1])
+
+    width = Int(get(entity.data, "width", 32))
+    height = Int(get(entity.data, "height", 32))
+
+    frame, trail, mid = getTextures(entity)
+
+    renderSwapBlock(ctx, stopX, stopY, width, height, mid, frame)
+    Ahorn.drawArrow(ctx, startX + width / 2, startY + height / 2, stopX + width / 2, stopY + height / 2, Ahorn.colors.selection_selected_fc, headLength=6)
+end
+
+function Ahorn.renderAbs(ctx::Ahorn.Cairo.CairoContext, entity::NoOutlineSwapBlock, room::Maple.Room)
+    sprite = get(entity.data, "sprite", "block")
+
+    startX, startY = Int(entity.data["x"]), Int(entity.data["y"])
+    stopX, stopY = Int.(entity.data["nodes"][1])
+
+    width = Int(get(entity.data, "width", 32))
+    height = Int(get(entity.data, "height", 32))
+
+    frame, trail, mid = getTextures(entity)
+
+    renderSwapBlock(ctx, startX, startY, width, height, mid, frame)
+end
+
+end

--- a/src/JankTempleTilesetEvent.cs
+++ b/src/JankTempleTilesetEvent.cs
@@ -29,7 +29,7 @@ namespace Celeste.Mod.AnarchyCollab2022 {
             Audio.Play(SFX.game_10_glitch_medium);
             Glitch.Value = 0.3f;
             yield return 0.2f;
-            ReplaceTiles(level, 'd', 'J');
+            ReplaceTiles(level, 'T', 'J');
             yield return 0.2f;
             Glitch.Value = 0f;
         }

--- a/src/NoOutlineSwapBlock.cs
+++ b/src/NoOutlineSwapBlock.cs
@@ -1,0 +1,27 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod.Utils;
+using System;
+using System.Collections;
+
+namespace Celeste.Mod.AnarchyCollab2022 {
+    [CustomEntity("AnarchyCollab2022/NoOutlineSwapBlock")]
+    public class NoOutlineSwapBlock : SwapBlock {
+        private DynamicData baseData;
+
+        public NoOutlineSwapBlock(EntityData data, Vector2 offset)
+            : base(data, offset) {
+            baseData = new DynamicData(typeof(SwapBlock), this);
+            float baseMaxForwardSpeed = baseData.Get<float>("maxForwardSpeed");
+            float speed = data.Float("speed", 360f);
+            baseData.Set("maxForwardSpeed", baseMaxForwardSpeed * (speed / 360f));
+        }
+
+        public override void Awake(Scene scene) {
+            base.Awake(scene);
+            Entity path = baseData.Get<Entity>("path");
+            path.Active = path.Visible = false;
+        }
+    }
+}


### PR DESCRIPTION
- added No Outline Swap Block (since normal swap block outlines apparently cause lag if you try to put their node several thousand tiles away... don't ask ![3c](https://user-images.githubusercontent.com/5523379/166101139-14c3a265-8b28-4e43-ad2e-894858fa7952.png))
- change the jank tileset swap to use tileset ID `T` instead of `d` since I'm now using a custom tileset for the map